### PR TITLE
Support handling for more variability in markdown title lines

### DIFF
--- a/lib/issues.js
+++ b/lib/issues.js
@@ -50,6 +50,18 @@ exports.severityNames = {
   'spec': 'Spec Breaking',
 }
 
+// Final report title lines should have a single format:
+//   ## [H-1] Not good thing
+//
+// Markdown title lines have more variability:
+//   ### [H-1] Not good thing
+//   ## (H-1) Also not good
+//   **[G-1]** Gassy code
+//
+// This RegExps will select any of these formats
+const ISSUE_TAG_RE = `[\\(\\[<](([CHMLQIG])-[0-9]+)[\\)\\]>]`
+const TITLE_LINE_RE = `^(#{1,3} +)?\\*{0,2}${ISSUE_TAG_RE}\\*{0,2} +(.+)`
+
 exports.statusNames = STATUSES
 
 exports.normalize = function normalizeIssue(issue) {
@@ -70,7 +82,7 @@ exports.normalize = function normalizeIssue(issue) {
 }
 
 function parseTitleLine(titleLine) {
-  const [, tag, severity, title] = titleLine.match(/^## +\((([CHMLQIG])-[0-9]+)\) +(.+)/)
+  const [,, tag, severity, title] = titleLine.match(new RegExp(TITLE_LINE_RE))
   return { tag, severity, title }
 }
 
@@ -108,39 +120,46 @@ const IMPACT_LABEL_RE = /(?:\*\*)?Impact(?:\*\*)?:(?:\*\*)? ([^\n]+)?/
 const CHANCE_LABEL_RE = /(?:\*\*)?Likelihood(?:\*\*)?:(?:\*\*)? ([^\n]+)?/
 
 exports.parseNotionMarkdownIssues = function parseNotionMarkdownIssues(markdown) {
-  return markdown.split(/(?=##\s+\([CHMLQGI]-\d\))/)
+  return markdown.split(new RegExp(`(?=${TITLE_LINE_RE})`))
     .filter(x => !x.match(/^[\s\n]*$/))
     .map(issueContent => {
-      issueContent = issueContent.trim()
       let impact = ''
       let chance = ''
 
-      const { severity } = parseTitleLine(issueContent.split('\n')[0])
+      const [firstLine, ...contentLines] = issueContent.trim().split('\n')
+      const { tag, severity, title } = parseTitleLine(firstLine)
+
+      // Normalize markdown title format for the final report:
+      //  ## [H-1] Not good thing
+      const issueTitle = `## [${tag}] ${title}`
+      let issueBody = contentLines.join('\n')
 
       // SORRY WINDOWS
-      const impactMatch = issueContent.match(IMPACT_LABEL_RE)
+      const impactMatch = issueBody.match(IMPACT_LABEL_RE)
       if (impactMatch) {
         impact = impactMatch[1].match(/spec/i) ? 'spec' : impactMatch[1].toLowerCase()
         if (!IMPACT_SEVERITIES.includes(impact)) {
           throw new Error(`Invalid impact: ${impact}`)
         }
+        issueBody = issueBody.replace(IMPACT_LABEL_RE, '')
       }
-      const chanceMatch = issueContent.match(CHANCE_LABEL_RE)
+      const chanceMatch = issueBody.match(CHANCE_LABEL_RE)
       if (chanceMatch) {
         chance = chanceMatch[1].toLowerCase()
         if (!CHANCE_SEVERITIES.includes(chance)) {
           throw new Error(`Invalid chance: ${chance}`)
         }
+        issueBody = issueBody.replace(CHANCE_LABEL_RE, '')
       }
+
+      //Remove all empty leading lines
+      issueBody = issueBody.replace(/^( *\n)+(.*)$/gm, '$2')
+
       return {
         impact,
         chance,
         severity,
-        content: issueContent
-          .replace(IMPACT_LABEL_RE, '')
-          .replace(CHANCE_LABEL_RE, '')
-          .replace(/(## [^\n]+)\n+/g, '$1\n\n') // Consolidate extra newlines
-        ,
+        content: issueTitle + '\n\n' + issueBody,
       }
     })
 }


### PR DESCRIPTION
Allow the Issue Formatter to process a wider array of markdown issue title formats.  Then normalize them into a single Final Report format.

Example Markdown Issue title formats we've used:

```
  ### [H-1] Not good thing
  ## (H-1) Also not good
  **[G-1]** Gassy code
```

Final report Issue title format:

```
  ## [H-1] Not good thing
```