### PR TITLE
fix: should be stack not storage

### DIFF
--- a/client/learn_evm/chapters/evm/storage.html
+++ b/client/learn_evm/chapters/evm/storage.html
@@ -134,7 +134,7 @@ Some familiar programming constructs, like strings and arrays, exist in language
 
 ## Storage Gas Costs
 
-The gas costs of operating on storage are much higher than operations on storage and memory. This makes sense, because changes to storage need to be persisted to disk by *all* nodes in the network after the transaction completes. In general, gas costs are higher for operations that require nodes to do more computation or use more resources.
+The gas costs of operating on storage are much higher than operations on stack and memory. This makes sense, because changes to storage need to be persisted to disk by *all* nodes in the network after the transaction completes. In general, gas costs are higher for operations that require nodes to do more computation or use more resources.
 
 <aside>
 


### PR DESCRIPTION
This pull request corrects a minor documentation error in the `client/learn_evm/chapters/evm/storage.html` file, clarifying that storage gas costs are higher than those for stack and memory (not "storage and memory").